### PR TITLE
chore: set up MDF project workflow state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,10 @@ template/packages/*/coverage/
 test-project/
 .env
 
+# MDF local workflow state
+.mdf/
+.worktrees/
+
 # OS artifacts
 .DS_Store
 *.pem


### PR DESCRIPTION
## Summary

- Add `.mdf/` and `.worktrees/` to `.gitignore` for local MDF workflow state.

## Notes

- No docs or agent-rule setup included because this starter template should keep MDF init setup minimal.