### PR TITLE
ci: align release signal with PR titles

### DIFF
--- a/.github/workflows/pr-release-check.yml
+++ b/.github/workflows/pr-release-check.yml
@@ -16,21 +16,46 @@ jobs:
         with:
           script: |
             const pr = context.payload.pull_request;
-            const text = [
-              pr.title || "",
-              pr.body || "",
-              ...(pr.labels || []).map((label) => label.name),
-            ].join("\n");
+            const title = pr.title || "";
+            const labels = (pr.labels || []).map((label) => label.name.toLowerCase());
+            const hasReleaseNone = labels.includes("release-none");
+            const bump = resolveConventionalCommitBump(title);
 
-            const releaseIntent = text.match(
-              /(?:release-version|release|version)\s*:\s*(major|minor|patch|none|(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-((?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?)(?![0-9A-Za-z.+-])/i
-            );
-
-            if (!releaseIntent) {
+            if (hasReleaseNone && bump) {
               core.setFailed(
-                "PR must declare release intent: release: major|minor|patch|none|x.y.z"
+                `Conflicting release signals: title resolves to ${bump}, but release-none label is present.`
               );
               return;
             }
 
-            core.info(`Release intent: ${releaseIntent[1]}`);
+            if (hasReleaseNone) {
+              core.info("Release intent: none (release-none label)");
+              return;
+            }
+
+            if (!bump) {
+              core.setFailed(
+                "PR title must use a release Conventional Commit type (feat, fix, docs, chore, refactor, perf, test, ci, build) or apply the release-none label."
+              );
+              return;
+            }
+
+            core.info(`Release intent: ${bump} (${title})`);
+
+            function resolveConventionalCommitBump(title) {
+              const releaseBumpTypes = new Map([
+                ["feat", "minor"],
+                ["fix", "patch"],
+                ["docs", "patch"],
+                ["chore", "patch"],
+                ["refactor", "patch"],
+                ["perf", "patch"],
+                ["test", "patch"],
+                ["ci", "patch"],
+                ["build", "patch"],
+              ]);
+              const match = title.match(/^([a-z]+)(?:\([^)]+\))?(!)?:\s+/);
+              if (!match) return "";
+              if (match[2]) return "major";
+              return releaseBumpTypes.get(match[1]) || "";
+            }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Exact version to publish, for example 0.1.9. Leave empty to run full release."
+        description: "Exact version to publish, for example 0.1.9. Leave empty to run without an exact version override."
         required: false
         type: string
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,6 @@ jobs:
         id: release
         run: |
           node <<'NODE'
-          const { execFileSync } = require("node:child_process");
           const fs = require("node:fs");
 
           const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
@@ -51,61 +50,31 @@ jobs:
           const pr = fs.existsSync("pr.json")
             ? JSON.parse(fs.readFileSync("pr.json", "utf8"))
             : {};
-          const labels = Array.isArray(pr.labels)
-            ? pr.labels.map((label) => label.name).join("\n")
-            : "";
-
-          const lastTag = (() => {
-            try {
-              return execFileSync("git", ["describe", "--tags", "--abbrev=0", "--match", "v[0-9]*"], {
-                encoding: "utf8",
-                stdio: ["ignore", "pipe", "ignore"],
-              }).trim();
-            } catch {
-              return "";
-            }
-          })();
-
-          const range = lastTag ? `${lastTag}..HEAD` : "HEAD";
-          const commits = execFileSync("git", ["log", range, "--format=%s%n%b"], {
-            encoding: "utf8",
-          });
-          const text = [
-            inputVersion,
-            pr.title || "",
-            pr.body || "",
-            labels,
-            process.env.HEAD_COMMIT || "",
-            commits,
-          ].join("\n");
+          const labels = Array.isArray(pr.labels) ? pr.labels.map((label) => label.name.toLowerCase()) : [];
+          const hasReleaseNone = labels.includes("release-none");
+          const title = pr.title || firstLine(process.env.HEAD_COMMIT || "");
 
           const semver = /^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-((?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
-          const releaseIntentRaw = text.match(
-            /(?:release-version|release|version)\s*:\s*(major|minor|patch|none|(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-((?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?)(?![0-9A-Za-z.+-])/i
-          )?.[1];
-          const releaseIntent = releaseIntentRaw?.toLowerCase();
-          const explicitVersion =
-            inputVersion ||
-            (releaseIntentRaw && semver.test(releaseIntentRaw) ? releaseIntentRaw : "");
+          const explicitVersion = inputVersion;
+          const titleBump = resolveConventionalCommitBump(title);
 
           let bump = "";
           if (explicitVersion) {
             bump = "exact";
-          } else if (["major", "minor", "patch", "none"].includes(releaseIntent)) {
-            bump = releaseIntent;
-          } else if (/BREAKING CHANGE|^[a-z]+(?:\([^)]+\))?!:/m.test(text)) {
-            bump = "major";
-          } else if (/^feat(?:\([^)]+\))?:/m.test(text)) {
-            bump = "minor";
-          } else if (/^(?:fix|perf|refactor)(?:\([^)]+\))?:/m.test(text)) {
-            bump = "patch";
+          } else if (hasReleaseNone && titleBump) {
+            throw new Error(
+              `Conflicting release signals: title resolves to ${titleBump}, but release-none label is present.`
+            );
+          } else if (hasReleaseNone) {
+            bump = "none";
+          } else {
+            bump = titleBump;
           }
 
           const nextVersion = bump === "none" ? "" : explicitVersion || bumpVersion(current, bump);
-          const output = fs.createWriteStream(process.env.GITHUB_OUTPUT, { flags: "a" });
 
           if (!nextVersion) {
-            output.write("has_changes=false\n");
+            writeOutput("has_changes=false");
             console.log("No releasable changes found.");
             process.exit(0);
           }
@@ -118,9 +87,13 @@ jobs:
             throw new Error(`Release version ${nextVersion} is lower than current version ${current}`);
           }
 
-          output.write("has_changes=true\n");
-          output.write(`version=${nextVersion}\n`);
+          writeOutput("has_changes=true");
+          writeOutput(`version=${nextVersion}`);
           console.log(`Release version resolved: ${nextVersion} (${bump})`);
+
+          function writeOutput(line) {
+            fs.appendFileSync(process.env.GITHUB_OUTPUT, `${line}\n`);
+          }
 
           function bumpVersion(version, type) {
             if (!type) return "";
@@ -129,6 +102,28 @@ jobs:
             if (type === "minor") return `${major}.${minor + 1}.0`;
             if (type === "patch") return `${major}.${minor}.${patch + 1}`;
             return "";
+          }
+
+          function firstLine(value) {
+            return value.split(/\r?\n/, 1)[0] || "";
+          }
+
+          function resolveConventionalCommitBump(title) {
+            const releaseBumpTypes = new Map([
+              ["feat", "minor"],
+              ["fix", "patch"],
+              ["docs", "patch"],
+              ["chore", "patch"],
+              ["refactor", "patch"],
+              ["perf", "patch"],
+              ["test", "patch"],
+              ["ci", "patch"],
+              ["build", "patch"],
+            ]);
+            const match = title.match(/^([a-z]+)(?:\([^)]+\))?(!)?:\s+/);
+            if (!match) return "";
+            if (match[2]) return "major";
+            return releaseBumpTypes.get(match[1]) || "";
           }
 
           function compareSemver(a, b) {

--- a/tests/unit/release-workflows.test.ts
+++ b/tests/unit/release-workflows.test.ts
@@ -7,15 +7,20 @@ import { afterEach, describe, expect, it } from "vitest";
 
 const prCheckWorkflow = ".github/workflows/pr-release-check.yml";
 const releaseWorkflow = ".github/workflows/release.yml";
+const fixtureVersion = "0.2.0";
 
 const tempFiles = new Set<string>();
+const tempDirs = new Set<string>();
 
 afterEach(() => {
   for (const file of tempFiles) {
     fs.rmSync(file, { force: true });
     tempFiles.delete(file);
   }
-  fs.rmSync("pr.json", { force: true });
+  for (const dir of tempDirs) {
+    fs.rmSync(dir, { force: true, recursive: true });
+    tempDirs.delete(dir);
+  }
 });
 
 describe("PR release check workflow", () => {
@@ -60,7 +65,7 @@ describe("PR release check workflow", () => {
 
 describe("release workflow resolver", () => {
   it("resolves PR titles using the same mapping as the PR check", () => {
-    expectReleaseVersion({ pr: pr("feat: add option") }, "0.3.0");
+    expectReleaseVersion({ pr: pr("feat: add option") }, bumpVersion(fixtureVersion, "minor"));
 
     for (const title of [
       "fix: repair release",
@@ -72,21 +77,21 @@ describe("release workflow resolver", () => {
       "ci: update workflow",
       "build: update package",
     ]) {
-      expectReleaseVersion({ pr: pr(title) }, "0.2.1");
+      expectReleaseVersion({ pr: pr(title) }, bumpVersion(fixtureVersion, "patch"));
     }
 
-    expectReleaseVersion({ pr: pr("feat!: change contract") }, "1.0.0");
-    expectReleaseVersion({ pr: pr("fix(api)!: change contract") }, "1.0.0");
+    expectReleaseVersion({ pr: pr("feat!: change contract") }, bumpVersion(fixtureVersion, "major"));
+    expectReleaseVersion({ pr: pr("fix(api)!: change contract") }, bumpVersion(fixtureVersion, "major"));
   });
 
-  it("uses the merge commit title when no PR title is available", () => {
+  it("uses the merge commit title as the explicit non-PR fallback", () => {
     expectReleaseVersion(
       { pr: {}, headCommit: "fix: fallback release\n\nbody text" },
-      "0.2.1",
+      bumpVersion(fixtureVersion, "patch"),
     );
   });
 
-  it("keeps exact workflow_dispatch versions independent from title resolution", () => {
+  it("keeps trusted exact workflow_dispatch versions independent from title resolution", () => {
     expectReleaseVersion({ pr: undefined, inputVersion: "0.2.5" }, "0.2.5");
     expectNoRelease({ pr: undefined });
   });
@@ -101,12 +106,12 @@ describe("release workflow resolver", () => {
     );
   });
 
-  it("documents title-only breaking release signaling", () => {
+  it("documents that title-only breaking releases require ! in the title", () => {
     expectReleaseVersion(
       { pr: { title: "feat: api", body: "BREAKING CHANGE: incompatible API", labels: [] } },
-      "0.3.0",
+      bumpVersion(fixtureVersion, "minor"),
     );
-    expectReleaseVersion({ pr: pr("feat!: api") }, "1.0.0");
+    expectReleaseVersion({ pr: pr("feat!: api") }, bumpVersion(fixtureVersion, "major"));
   });
 });
 
@@ -176,9 +181,12 @@ function runReleaseResolver({
 }) {
   const script = extractReleaseScript();
   const output = tempFile();
+  const cwd = tempDir();
+
+  fs.writeFileSync(path.join(cwd, "package.json"), JSON.stringify({ version: fixtureVersion }));
 
   if (pr !== undefined) {
-    fs.writeFileSync("pr.json", JSON.stringify(pr));
+    fs.writeFileSync(path.join(cwd, "pr.json"), JSON.stringify(pr));
   }
 
   try {
@@ -190,6 +198,7 @@ function runReleaseResolver({
         HEAD_COMMIT: headCommit,
         INPUT_VERSION: inputVersion,
       },
+      cwd,
       stdio: ["ignore", "pipe", "pipe"],
     });
 
@@ -239,4 +248,17 @@ function tempFile() {
   const file = path.join(os.tmpdir(), `release-workflow-test-${Date.now()}-${Math.random()}`);
   tempFiles.add(file);
   return file;
+}
+
+function tempDir() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "release-workflow-test-"));
+  tempDirs.add(dir);
+  return dir;
+}
+
+function bumpVersion(version: string, type: "major" | "minor" | "patch") {
+  const [major, minor, patch] = version.split(".").map(Number);
+  if (type === "major") return `${major + 1}.0.0`;
+  if (type === "minor") return `${major}.${minor + 1}.0`;
+  return `${major}.${minor}.${patch + 1}`;
 }

--- a/tests/unit/release-workflows.test.ts
+++ b/tests/unit/release-workflows.test.ts
@@ -1,0 +1,242 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import vm from "node:vm";
+import { afterEach, describe, expect, it } from "vitest";
+
+const prCheckWorkflow = ".github/workflows/pr-release-check.yml";
+const releaseWorkflow = ".github/workflows/release.yml";
+
+const tempFiles = new Set<string>();
+
+afterEach(() => {
+  for (const file of tempFiles) {
+    fs.rmSync(file, { force: true });
+    tempFiles.delete(file);
+  }
+  fs.rmSync("pr.json", { force: true });
+});
+
+describe("PR release check workflow", () => {
+  it("accepts title-based release signals without body metadata", () => {
+    for (const [title, expected] of [
+      ["feat: add option", "minor"],
+      ["fix: repair release", "patch"],
+      ["docs: update release docs", "patch"],
+      ["chore: update deps", "patch"],
+      ["refactor: simplify resolver", "patch"],
+      ["perf: improve release", "patch"],
+      ["test: add coverage", "patch"],
+      ["ci: update workflow", "patch"],
+      ["build: update package", "patch"],
+      ["feat!: change contract", "major"],
+      ["fix(api)!: change contract", "major"],
+    ]) {
+      const result = runPrCheck({ title, body: "", labels: [] });
+
+      expect(result.failures, title).toEqual([]);
+      expect(result.infos.join("\n"), title).toContain(expected);
+    }
+  });
+
+  it("accepts release-none only when the title is not release-producing", () => {
+    const noRelease = runPrCheck({
+      title: "maintenance update",
+      body: "",
+      labels: [{ name: "Release-None" }],
+    });
+    const conflict = runPrCheck({
+      title: "fix: repair release",
+      body: "",
+      labels: [{ name: "release-none" }],
+    });
+
+    expect(noRelease.failures).toEqual([]);
+    expect(noRelease.infos.join("\n")).toContain("none");
+    expect(conflict.failures.join("\n")).toContain("Conflicting release signals");
+  });
+});
+
+describe("release workflow resolver", () => {
+  it("resolves PR titles using the same mapping as the PR check", () => {
+    expectReleaseVersion({ pr: pr("feat: add option") }, "0.3.0");
+
+    for (const title of [
+      "fix: repair release",
+      "docs: update release docs",
+      "chore: update deps",
+      "refactor: simplify resolver",
+      "perf: improve release",
+      "test: add coverage",
+      "ci: update workflow",
+      "build: update package",
+    ]) {
+      expectReleaseVersion({ pr: pr(title) }, "0.2.1");
+    }
+
+    expectReleaseVersion({ pr: pr("feat!: change contract") }, "1.0.0");
+    expectReleaseVersion({ pr: pr("fix(api)!: change contract") }, "1.0.0");
+  });
+
+  it("uses the merge commit title when no PR title is available", () => {
+    expectReleaseVersion(
+      { pr: {}, headCommit: "fix: fallback release\n\nbody text" },
+      "0.2.1",
+    );
+  });
+
+  it("keeps exact workflow_dispatch versions independent from title resolution", () => {
+    expectReleaseVersion({ pr: undefined, inputVersion: "0.2.5" }, "0.2.5");
+    expectNoRelease({ pr: undefined });
+  });
+
+  it("handles release-none conflicts and no-release cases", () => {
+    expectNoRelease({
+      pr: { title: "maintenance update", body: "", labels: [{ name: "release-none" }] },
+    });
+    expectReleaseFailure(
+      { pr: { title: "fix: repair release", body: "", labels: [{ name: "release-none" }] } },
+      /Conflicting release signals/,
+    );
+  });
+
+  it("documents title-only breaking release signaling", () => {
+    expectReleaseVersion(
+      { pr: { title: "feat: api", body: "BREAKING CHANGE: incompatible API", labels: [] } },
+      "0.3.0",
+    );
+    expectReleaseVersion({ pr: pr("feat!: api") }, "1.0.0");
+  });
+});
+
+function pr(title: string) {
+  return { title, body: "", labels: [] };
+}
+
+function runPrCheck(pullRequest: { title: string; body: string; labels: Array<{ name: string }> }) {
+  const script = extractGithubScript(prCheckWorkflow);
+  const failures: string[] = [];
+  const infos: string[] = [];
+  const sandbox = {
+    context: { payload: { pull_request: pullRequest } },
+    core: {
+      setFailed(message: string) {
+        failures.push(message);
+      },
+      info(message: string) {
+        infos.push(message);
+      },
+    },
+  };
+
+  vm.runInNewContext(`(() => {\n${script}\n})()`, sandbox);
+
+  return { failures, infos };
+}
+
+function expectReleaseVersion(
+  scenario: { pr?: { title?: string; body?: string; labels?: Array<{ name: string }> }; inputVersion?: string; headCommit?: string },
+  version: string,
+) {
+  const result = runReleaseResolver(scenario);
+
+  expect(result.ok, result.stderr || result.stdout).toBe(true);
+  expect(result.output).toContain("has_changes=true");
+  expect(result.output).toContain(`version=${version}`);
+}
+
+function expectNoRelease(
+  scenario: { pr?: { title?: string; body?: string; labels?: Array<{ name: string }> }; inputVersion?: string; headCommit?: string },
+) {
+  const result = runReleaseResolver(scenario);
+
+  expect(result.ok, result.stderr || result.stdout).toBe(true);
+  expect(result.output).toContain("has_changes=false");
+}
+
+function expectReleaseFailure(
+  scenario: { pr?: { title?: string; body?: string; labels?: Array<{ name: string }> }; inputVersion?: string; headCommit?: string },
+  pattern: RegExp,
+) {
+  const result = runReleaseResolver(scenario);
+
+  expect(result.ok).toBe(false);
+  expect(`${result.stdout}\n${result.stderr}`).toMatch(pattern);
+}
+
+function runReleaseResolver({
+  pr,
+  inputVersion = "",
+  headCommit = "",
+}: {
+  pr?: { title?: string; body?: string; labels?: Array<{ name: string }> };
+  inputVersion?: string;
+  headCommit?: string;
+}) {
+  const script = extractReleaseScript();
+  const output = tempFile();
+
+  if (pr !== undefined) {
+    fs.writeFileSync("pr.json", JSON.stringify(pr));
+  }
+
+  try {
+    const stdout = execFileSync(process.execPath, ["-e", script], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        GITHUB_OUTPUT: output,
+        HEAD_COMMIT: headCommit,
+        INPUT_VERSION: inputVersion,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    return {
+      ok: true,
+      output: fs.existsSync(output) ? fs.readFileSync(output, "utf8") : "",
+      stdout,
+      stderr: "",
+    };
+  } catch (error) {
+    const commandError = error as { stdout?: Buffer; stderr?: Buffer };
+    return {
+      ok: false,
+      output: fs.existsSync(output) ? fs.readFileSync(output, "utf8") : "",
+      stdout: commandError.stdout?.toString() || "",
+      stderr: commandError.stderr?.toString() || "",
+    };
+  }
+}
+
+function extractGithubScript(file: string) {
+  const workflow = fs.readFileSync(file, "utf8");
+  const match = workflow.match(/script: \|\n([\s\S]*)$/);
+
+  if (!match) throw new Error(`script block not found in ${file}`);
+
+  return match[1]
+    .split("\n")
+    .map((line) => (line.startsWith("            ") ? line.slice(12) : line))
+    .join("\n");
+}
+
+function extractReleaseScript() {
+  const lines = fs.readFileSync(releaseWorkflow, "utf8").split("\n");
+  const start = lines.findIndex((line) => line.includes("node <<'NODE'"));
+  const end = lines.findIndex((line, index) => index > start && line === "          NODE");
+
+  if (start < 0 || end < 0) throw new Error("release node script block not found");
+
+  return lines
+    .slice(start + 1, end)
+    .map((line) => line.replace(/^          /, ""))
+    .join("\n");
+}
+
+function tempFile() {
+  const file = path.join(os.tmpdir(), `release-workflow-test-${Date.now()}-${Math.random()}`);
+  tempFiles.add(file);
+  return file;
+}


### PR DESCRIPTION
## Summary
- PR 제목 기반 Conventional Commit release signal로 PR 검증과 release resolver를 정렬했습니다.
- `release-none` 충돌 검증과 merged PR title / HEAD_COMMIT fallback 경로를 명확히 했습니다.
- workflow resolver 동작을 repo 테스트로 고정했습니다.

## Design
- `.github/workflows/pr-release-check.yml`은 PR title과 `release-none` label만으로 release intent를 판단합니다.
- `.github/workflows/release.yml`은 merged PR title을 우선 사용하고, PR title이 없을 때만 merge commit title의 첫 줄을 fallback으로 사용합니다.
- `workflow_dispatch` exact version override는 trusted manual path로 유지하며 semver validation을 그대로 통과합니다.
- `tests/unit/release-workflows.test.ts`는 workflow 안의 embedded JavaScript를 직접 추출해 실행하므로 별도 병렬 구현 drift를 줄입니다.

## Service Impact
- 일반 release PR은 더 이상 PR body에 `release: patch` 같은 release intent line을 넣지 않아도 됩니다.
- breaking release는 PR title의 `!`로 표시해야 하며, body의 `BREAKING CHANGE` footer는 release bump signal로 사용하지 않습니다.
- 외부 서비스, secret, 환경 변수, 데이터 저장소 변경은 없습니다.

## Operational Checklist
- [x] No manual operational actions required.

## Test Plan
- [x] `pnpm test tests/unit/release-workflows.test.ts`
- [x] `pnpm test`
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] Ship fan-out GO: code-reviewer, security-auditor, test-engineer

## MDF
- Completed task: 0005
- Spec: `.mdf/work/2026-06-17-0005-align-pr-release-signal/spec-001.md`
- Plan: `.mdf/work/2026-06-17-0005-align-pr-release-signal/plan-001.md`
- Build: `.mdf/work/2026-06-17-0005-align-pr-release-signal/build-005.md`
- Review: `.mdf/work/2026-06-17-0005-align-pr-release-signal/review-010.md`
- Ship: `.mdf/work/2026-06-17-0005-align-pr-release-signal/ship-002.md`
