### PR TITLE
ci: install pnpm before npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -296,6 +296,8 @@ jobs:
           name: release-dist
           path: dist
 
+      - uses: pnpm/action-setup@v4
+
       - uses: actions/setup-node@v4
         with:
           node-version: "24"

--- a/tests/unit/release-workflows.test.ts
+++ b/tests/unit/release-workflows.test.ts
@@ -115,6 +115,19 @@ describe("release workflow resolver", () => {
   });
 });
 
+describe("release publish job", () => {
+  it("installs pnpm before npm publish triggers prepublishOnly", () => {
+    const workflow = fs.readFileSync(releaseWorkflow, "utf8");
+    const publishJob = workflow.slice(workflow.indexOf("  publish:"));
+    const pnpmSetup = publishJob.indexOf("uses: pnpm/action-setup@v4");
+    const publishStep = publishJob.indexOf("run: npm publish --provenance --access public");
+
+    expect(pnpmSetup).toBeGreaterThanOrEqual(0);
+    expect(publishStep).toBeGreaterThanOrEqual(0);
+    expect(pnpmSetup).toBeLessThan(publishStep);
+  });
+});
+
 function pr(title: string) {
   return { title, body: "", labels: [] };
 }


### PR DESCRIPTION
## Summary
- Release workflow의 publish job에서 npm publish 전에 pnpm을 설치하도록 수정했습니다.
- npm publish가 실행하는 prepublishOnly의 pnpm 호출 실패를 막는 회귀 테스트를 추가했습니다.

## Design
- publish job에 기존 verify job과 같은 pnpm/action-setup@v4 단계를 추가해 packageManager에 선언된 pnpm을 PATH에 준비합니다.
- release workflow 테스트는 publish job 안에서 pnpm setup이 npm publish보다 먼저 배치되는지를 검증합니다.

## Service Impact
- 사용자 기능 변경은 없습니다. npm 배포 자동화가 prepublishOnly 단계에서 pnpm을 찾지 못해 실패하던 문제만 해결합니다.
- 환경 변수, 시크릿, 외부 서비스 설정 변경은 없습니다.

## Operational Checklist
- [x] No manual operational actions required.

## Test Plan
- [x] pnpm test:pack-env
- [x] pnpm vitest run tests/unit/release-workflows.test.ts
- [x] pnpm test
- [x] pnpm typecheck

## MDF
- Completed task: n/a (direct CI follow-up fix, no MDF task id)