### PR TITLE
Update npm provenance metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,20 +72,27 @@ cd test-project && pnpm dev
 
 릴리스는 GitHub Actions로 자동화됨.
 
-1. PR 제목, 본문, 또는 라벨에 릴리스 의도 선언
+1. PR 제목을 Conventional Commit 형식으로 작성
 
 ```text
-release: major
-release: minor
-release: patch
-release: none
-release: 1.2.3
+feat: add capability        # minor
+fix: correct behavior       # patch
+docs: update release docs   # patch
+ci: update workflow         # patch
+feat!: change contract      # major
 ```
 
-2. PR merge 후 `main` push에서 `.github/workflows/release.yml` 실행
-3. workflow가 버전 결정, `chore(release): vX.Y.Z` 커밋, 태그, GitHub Release, npm publish 수행
+2. 비릴리스 PR은 `release-none` 라벨 적용
+3. PR merge 후 `main` push에서 `.github/workflows/release.yml` 실행
+4. workflow가 버전 결정, `chore(release): vX.Y.Z` 커밋, 태그, GitHub Release, npm publish 수행
 
-비릴리스 PR은 `release: none` 사용.
+수동으로 특정 버전을 재시도해야 할 때는 `workflow_dispatch`로 Release workflow를 실행하고 `version`에 정확한 semver를 입력.
+
+```text
+0.2.2
+```
+
+이미 tag 또는 GitHub Release가 있으면 workflow가 해당 단계는 건너뛰고, npm에 같은 버전이 없을 때 publish를 다시 시도함.
 
 ### npm Trusted Publishing
 
@@ -100,3 +107,5 @@ workflow는 npm 토큰 없이 OIDC provenance publish 사용:
 ```bash
 npm publish --provenance --access public
 ```
+
+provenance 검증을 위해 root `package.json`의 `repository.url`은 GitHub repository와 매칭되어야 함.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "@jjlabsio/create-jjlabs-app",
   "version": "0.2.2",
   "description": "CLI to scaffold a new JJLabs app from the starter template",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jjlabsio/jjlabsio-starter.git"
+  },
   "type": "module",
   "bin": {
     "create-jjlabs-app": "dist/index.js"

--- a/tests/unit/package-env-safety.test.ts
+++ b/tests/unit/package-env-safety.test.ts
@@ -9,6 +9,15 @@ import {
 } from "../../scripts/check-pack-env.mjs";
 
 describe("package env safety", () => {
+  it("declares repository metadata required by npm provenance", () => {
+    const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+
+    expect(pkg.repository).toEqual({
+      type: "git",
+      url: "git+https://github.com/jjlabsio/jjlabsio-starter.git",
+    });
+  });
+
   it("passes when all expected env examples are packed and no real env files are present", () => {
     const result = analyzePackFiles([
       "dist/index.js",


### PR DESCRIPTION
## Summary
- npm trusted publishing의 provenance 검증에 필요한 root `package.json` repository metadata를 추가했습니다.
- README의 Publishing 섹션을 현재 release workflow와 `0.2.2` publish 재시도 절차에 맞게 정리했습니다.
- repository metadata가 빠지면 테스트에서 잡히도록 package safety 테스트를 보강했습니다.

## Design
- `../md-to-naver-blog`의 실제 npm publish 패키지와 같은 `git+https://github.com/jjlabsio/jjlabsio-starter.git` repository URL 형식을 사용했습니다.
- 이 PR은 이미 생성된 `v0.2.2` tag/GitHub Release를 보존하고, merge 후 `workflow_dispatch version=0.2.2`로 npm publish만 재시도하는 복구 흐름을 전제로 합니다.

## Service Impact
- 런타임 사용자 기능 변경은 없습니다.
- npm package metadata가 보강되어 GitHub Actions OIDC provenance publish가 repository 정보를 검증할 수 있게 됩니다.
- 이 PR 자체는 새 npm 버전을 만들면 안 되므로 `release-none` 라벨이 필요합니다.

## Operational Checklist
- [x] `release-none` 라벨을 이 PR에 적용합니다.
- [ ] PR merge 후 GitHub Actions `Release` workflow를 수동 실행하고 `version`에 `0.2.2`를 입력합니다.
- [ ] workflow 성공 후 `npm view @jjlabsio/create-jjlabs-app@0.2.2 version repository --json`으로 npm publish를 확인합니다.

## Test Plan
- [x] `npm pkg get repository --json`
- [x] `npm pack --dry-run --json`
- [x] `pnpm vitest run tests/unit/package-env-safety.test.ts`
- [x] `pnpm test:pack-env`
- [x] `pnpm vitest run tests/unit/release-workflows.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`

## MDF
- Completed task: 0006