### PR TITLE
feat: add NestJS worker app

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ CLI 실행 파일 이름은 `create-jjlabs-app`.
 - `apps/app`: 인증, 결제, 대시보드가 포함된 SaaS 앱
 - `apps/web`: 랜딩/마케팅 웹 앱
 - `apps/api`: NestJS API 앱
+- `apps/worker`: NestJS Worker 앱
 - `packages/*`: auth, billing, database, email, ui 등 공유 패키지
 
 생성 후 `README.md`에 초기 설정 절차가 포함됨.

--- a/scripts/e2e-smoke.mjs
+++ b/scripts/e2e-smoke.mjs
@@ -4,6 +4,7 @@ import path from "node:path";
 
 const PROJECT_NAME = "test-project";
 const API_PORT = 4312;
+const WORKER_PORT = 4313;
 const PROJECT_DIR = path.join(process.cwd(), PROJECT_NAME);
 const STATE_HOME_DIR = path.join(process.cwd(), ".tmp-e2e-home");
 
@@ -99,6 +100,7 @@ function assertGeneratedPorts() {
   const webPackagePath = path.join(PROJECT_DIR, "apps/web/package.json");
   const databaseEnvPath = path.join(PROJECT_DIR, "packages/database/.env");
   const apiMainPath = path.join(PROJECT_DIR, "apps/api/src/main.ts");
+  const workerMainPath = path.join(PROJECT_DIR, "apps/worker/src/main.ts");
   const dockerComposePath = path.join(PROJECT_DIR, "docker-compose.yml");
   const registryPath = path.join(
     STATE_HOME_DIR,
@@ -112,12 +114,14 @@ function assertGeneratedPorts() {
   const webPackage = fs.readFileSync(webPackagePath, "utf8");
   const databaseEnv = fs.readFileSync(databaseEnvPath, "utf8");
   const apiMain = fs.readFileSync(apiMainPath, "utf8");
+  const workerMain = fs.readFileSync(workerMainPath, "utf8");
   const dockerCompose = fs.readFileSync(dockerComposePath, "utf8");
   const registry = JSON.parse(fs.readFileSync(registryPath, "utf8"));
   const portSet = registry.projects[PROJECT_DIR]?.portSet;
   const appPort = 3100 + portSet * 100;
   const webPort = 3101 + portSet * 100;
   const apiPort = 3102 + portSet * 100;
+  const workerPort = 3103 + portSet * 100;
   const postgresPort = 5532 + portSet * 100;
 
   if (!Number.isInteger(portSet)) {
@@ -154,6 +158,10 @@ function assertGeneratedPorts() {
 
   if (!apiMain.includes(`const DEFAULT_PORT = ${apiPort};`)) {
     throw new Error("Expected generated API main.ts to include selected API port");
+  }
+
+  if (!workerMain.includes(`const DEFAULT_PORT = ${workerPort};`)) {
+    throw new Error("Expected generated worker main.ts to include selected worker port");
   }
 
   if (!dockerCompose.includes(`\"${postgresPort}:5432\"`)) {
@@ -234,30 +242,52 @@ async function assertApiRuntime() {
   }
 }
 
+async function assertWorkerRuntime() {
+  const worker = spawn("pnpm", ["--filter", "worker", "start"], {
+    cwd: PROJECT_DIR,
+    env: {
+      ...process.env,
+      PORT: String(WORKER_PORT),
+    },
+    stdio: "inherit",
+  });
+
+  try {
+    await waitForHealth(`http://127.0.0.1:${WORKER_PORT}/health`);
+  } finally {
+    worker.kill("SIGINT");
+  }
+}
+
 async function main() {
   fs.rmSync(PROJECT_DIR, { recursive: true, force: true });
   fs.rmSync(STATE_HOME_DIR, { recursive: true, force: true });
 
-  run("pnpm", ["build"]);
-  await runInteractive("node", ["dist/index.js", PROJECT_NAME], {
-    env: {
-      ...process.env,
-      JJLABSIO_STARTER_HOME: STATE_HOME_DIR,
-    },
-    inputs: ["\n", "\n"],
-  });
+  try {
+    run("pnpm", ["build"]);
+    await runInteractive("node", ["dist/index.js", PROJECT_NAME], {
+      env: {
+        ...process.env,
+        JJLABSIO_STARTER_HOME: STATE_HOME_DIR,
+      },
+      inputs: ["\n", "\n"],
+    });
 
-  assertGeneratedEnvFiles();
-  assertGeneratedPorts();
-  assertNoStalePortRuntimeReferences();
+    assertGeneratedEnvFiles();
+    assertGeneratedPorts();
+    assertNoStalePortRuntimeReferences();
 
-  run("pnpm", ["typecheck"], { cwd: PROJECT_DIR });
-  run("pnpm", ["test"], { cwd: PROJECT_DIR });
-  run("pnpm", ["build"], { cwd: PROJECT_DIR });
-  await assertApiRuntime();
+    run("pnpm", ["typecheck"], { cwd: PROJECT_DIR });
+    run("pnpm", ["lint"], { cwd: PROJECT_DIR });
+    run("pnpm", ["test"], { cwd: PROJECT_DIR });
+    run("pnpm", ["build"], { cwd: PROJECT_DIR });
+    await assertApiRuntime();
+    await assertWorkerRuntime();
+  } finally {
+    fs.rmSync(PROJECT_DIR, { recursive: true, force: true });
+    fs.rmSync(STATE_HOME_DIR, { recursive: true, force: true });
+  }
 
-  fs.rmSync(PROJECT_DIR, { recursive: true, force: true });
-  fs.rmSync(STATE_HOME_DIR, { recursive: true, force: true });
   console.log("e2e smoke test passed.");
 }
 

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -129,6 +129,7 @@ function formatPortPreview(selected: AssignedLocalPorts): string {
     `app ${selected.ports.app}`,
     `web ${selected.ports.web}`,
     `api ${selected.ports.api}`,
+    `worker ${selected.ports.worker}`,
     `postgres ${selected.ports.postgres}`,
   ].join(" ");
 }

--- a/src/scaffold.ts
+++ b/src/scaffold.ts
@@ -41,6 +41,7 @@ export async function scaffold(options: ScaffoldOptions): Promise<void> {
   logger.info(`  app:      http://localhost:${localPorts.ports.app}`);
   logger.info(`  web:      http://localhost:${localPorts.ports.web}`);
   logger.info(`  api:      http://localhost:${localPorts.ports.api}`);
+  logger.info(`  worker:   http://localhost:${localPorts.ports.worker}`);
   logger.info(`  postgres: localhost:${localPorts.ports.postgres}`);
   logger.info("Next steps:");
   logger.info(`  cd ${projectName}`);

--- a/src/steps/assign-local-ports.ts
+++ b/src/steps/assign-local-ports.ts
@@ -9,6 +9,7 @@ const MAX_PORT_SET = 500;
 
 const PORT_TEMPLATE_FILES = [
   "apps/api/src/main.ts",
+  "apps/worker/src/main.ts",
   "apps/app/package.json",
   "apps/app/.env.example",
   "apps/web/package.json",
@@ -22,6 +23,7 @@ export interface LocalPorts {
   readonly app: number;
   readonly web: number;
   readonly api: number;
+  readonly worker: number;
   readonly postgres: number;
 }
 
@@ -50,6 +52,7 @@ export function getPortsForSet(portSet: number): LocalPorts {
     app: 3100 + portSet * 100,
     web: 3101 + portSet * 100,
     api: 3102 + portSet * 100,
+    worker: 3103 + portSet * 100,
     postgres: 5532 + portSet * 100,
   };
 }
@@ -229,6 +232,7 @@ async function applyLocalPorts(
     "{{LOCAL_APP_PORT}}": String(ports.app),
     "{{LOCAL_WEB_PORT}}": String(ports.web),
     "{{LOCAL_API_PORT}}": String(ports.api),
+    "{{LOCAL_WORKER_PORT}}": String(ports.worker),
     "{{LOCAL_POSTGRES_PORT}}": String(ports.postgres),
   };
 

--- a/template/README.md
+++ b/template/README.md
@@ -128,6 +128,13 @@ pnpm dev
 
 `pnpm dev`는 workspace dev task를 실행합니다. 앱별 포트는 scaffold 중 배정된 값을 사용합니다.
 
+생성되는 workspace 앱:
+
+- `apps/app`: 인증, 결제, 대시보드가 포함된 SaaS 앱
+- `apps/web`: 랜딩/마케팅 웹 앱
+- `apps/api`: NestJS API 앱
+- `apps/worker`: NestJS Worker 앱
+
 ## Commands
 
 ```bash

--- a/template/apps/worker/eslint.config.mjs
+++ b/template/apps/worker/eslint.config.mjs
@@ -1,0 +1,4 @@
+import { config } from "@repo/eslint-config/base";
+
+/** @type {import("eslint").Linter.Config} */
+export default config;

--- a/template/apps/worker/nest-cli.json
+++ b/template/apps/worker/nest-cli.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json.schemastore.org/nest-cli",
+  "collection": "@nestjs/schematics",
+  "sourceRoot": "src",
+  "compilerOptions": {
+    "deleteOutDir": true,
+    "tsConfigPath": "tsconfig.build.json"
+  }
+}

--- a/template/apps/worker/package.json
+++ b/template/apps/worker/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "worker",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "generate:deps": "pnpm --filter @repo/database db:generate",
+    "build:deps": "pnpm --filter @repo/database build",
+    "predev": "pnpm run build:deps",
+    "dev": "nest start --watch",
+    "prebuild": "pnpm run build:deps",
+    "build": "nest build",
+    "start": "node dist/main.js",
+    "prestart:debug": "pnpm run build:deps",
+    "start:debug": "nest start --debug --watch",
+    "lint": "eslint . --max-warnings 0",
+    "pretypecheck": "pnpm run generate:deps",
+    "typecheck": "tsc --noEmit",
+    "pretest": "pnpm run build:deps",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@nestjs/common": "^11.1.11",
+    "@nestjs/core": "^11.1.11",
+    "@nestjs/platform-express": "^11.1.11",
+    "@repo/database": "workspace:*",
+    "reflect-metadata": "^0.2.2",
+    "rxjs": "^7.8.2"
+  },
+  "devDependencies": {
+    "@nestjs/cli": "^11.0.14",
+    "@nestjs/testing": "^11.1.11",
+    "@repo/eslint-config": "workspace:*",
+    "@repo/typescript-config": "workspace:*",
+    "@types/node": "^20",
+    "eslint": "^9.32.0",
+    "typescript": "^5.9.2",
+    "vitest": "^3.2.4"
+  }
+}

--- a/template/apps/worker/src/app.controller.test.ts
+++ b/template/apps/worker/src/app.controller.test.ts
@@ -1,0 +1,23 @@
+import "reflect-metadata";
+
+import { Test } from "@nestjs/testing";
+import { describe, expect, it } from "vitest";
+
+import { AppController } from "./app.controller";
+import { AppService } from "./app.service";
+
+describe("AppController", () => {
+  it("returns the worker service name", async () => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [AppController],
+      providers: [AppService],
+    }).compile();
+
+    const controller = moduleRef.get(AppController);
+
+    expect(controller.getRoot()).toEqual({
+      name: "jjlabsio-starter-worker",
+      status: "ok",
+    });
+  });
+});

--- a/template/apps/worker/src/app.controller.ts
+++ b/template/apps/worker/src/app.controller.ts
@@ -1,0 +1,13 @@
+import { Controller, Get, Inject } from "@nestjs/common";
+
+import { AppService } from "./app.service";
+
+@Controller()
+export class AppController {
+  constructor(@Inject(AppService) private readonly appService: AppService) {}
+
+  @Get()
+  getRoot() {
+    return this.appService.getRoot();
+  }
+}

--- a/template/apps/worker/src/app.module.ts
+++ b/template/apps/worker/src/app.module.ts
@@ -1,0 +1,12 @@
+import { Module } from "@nestjs/common";
+
+import { AppController } from "./app.controller";
+import { AppService } from "./app.service";
+import { HealthModule } from "./health/health.module";
+
+@Module({
+  imports: [HealthModule],
+  controllers: [AppController],
+  providers: [AppService],
+})
+export class AppModule {}

--- a/template/apps/worker/src/app.service.ts
+++ b/template/apps/worker/src/app.service.ts
@@ -1,0 +1,11 @@
+import { Injectable } from "@nestjs/common";
+
+@Injectable()
+export class AppService {
+  getRoot() {
+    return {
+      name: "jjlabsio-starter-worker",
+      status: "ok",
+    };
+  }
+}

--- a/template/apps/worker/src/db-package-contract.test.ts
+++ b/template/apps/worker/src/db-package-contract.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+
+describe("@repo/database package contract", () => {
+  it("exposes the shared Prisma client through the prisma subpath", async () => {
+    const { default: prisma, database } = await import("@repo/database/prisma");
+
+    expect(prisma).toBe(database);
+    expect(typeof prisma.$connect).toBe("function");
+    expect(typeof prisma.$disconnect).toBe("function");
+  });
+});

--- a/template/apps/worker/src/health/health.controller.test.ts
+++ b/template/apps/worker/src/health/health.controller.test.ts
@@ -1,0 +1,18 @@
+import "reflect-metadata";
+
+import { Test } from "@nestjs/testing";
+import { describe, expect, it } from "vitest";
+
+import { HealthController } from "./health.controller";
+
+describe("HealthController", () => {
+  it("returns an ok health response", async () => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [HealthController],
+    }).compile();
+
+    const controller = moduleRef.get(HealthController);
+
+    expect(controller.getHealth()).toEqual({ status: "ok" });
+  });
+});

--- a/template/apps/worker/src/health/health.controller.ts
+++ b/template/apps/worker/src/health/health.controller.ts
@@ -1,0 +1,9 @@
+import { Controller, Get } from "@nestjs/common";
+
+@Controller("health")
+export class HealthController {
+  @Get()
+  getHealth() {
+    return { status: "ok" };
+  }
+}

--- a/template/apps/worker/src/health/health.module.ts
+++ b/template/apps/worker/src/health/health.module.ts
@@ -1,0 +1,8 @@
+import { Module } from "@nestjs/common";
+
+import { HealthController } from "./health.controller";
+
+@Module({
+  controllers: [HealthController],
+})
+export class HealthModule {}

--- a/template/apps/worker/src/main.ts
+++ b/template/apps/worker/src/main.ts
@@ -1,0 +1,25 @@
+import "reflect-metadata";
+
+import { NestFactory } from "@nestjs/core";
+
+import { AppModule } from "./app.module";
+
+const DEFAULT_PORT = {{LOCAL_WORKER_PORT}};
+const DEFAULT_HOST = "127.0.0.1";
+
+function getPort() {
+  const port = Number.parseInt(process.env.PORT ?? "", 10);
+  return Number.isInteger(port) && port > 0 ? port : DEFAULT_PORT;
+}
+
+function getHost() {
+  return process.env.HOST || DEFAULT_HOST;
+}
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+
+  await app.listen(getPort(), getHost());
+}
+
+void bootstrap();

--- a/template/apps/worker/tsconfig.build.json
+++ b/template/apps/worker/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
+}

--- a/template/apps/worker/tsconfig.json
+++ b/template/apps/worker/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@repo/typescript-config/base.json",
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/template/apps/worker/vitest.config.ts
+++ b/template/apps/worker/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/template/pnpm-lock.yaml
+++ b/template/pnpm-lock.yaml
@@ -213,6 +213,52 @@ importers:
         specifier: ^5
         version: 5.9.3
 
+  apps/worker:
+    dependencies:
+      '@nestjs/common':
+        specifier: ^11.1.11
+        version: 11.1.26(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core':
+        specifier: ^11.1.11
+        version: 11.1.26(@nestjs/common@11.1.26(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.26)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/platform-express':
+        specifier: ^11.1.11
+        version: 11.1.26(@nestjs/common@11.1.26(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.26)
+      '@repo/database':
+        specifier: workspace:*
+        version: link:../../packages/database
+      reflect-metadata:
+        specifier: ^0.2.2
+        version: 0.2.2
+      rxjs:
+        specifier: ^7.8.2
+        version: 7.8.2
+    devDependencies:
+      '@nestjs/cli':
+        specifier: ^11.0.14
+        version: 11.0.23(@types/node@20.19.35)(prettier@3.8.1)
+      '@nestjs/testing':
+        specifier: ^11.1.11
+        version: 11.1.26(@nestjs/common@11.1.26(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.26)(@nestjs/platform-express@11.1.26)
+      '@repo/eslint-config':
+        specifier: workspace:*
+        version: link:../../packages/eslint-config
+      '@repo/typescript-config':
+        specifier: workspace:*
+        version: link:../../packages/typescript-config
+      '@types/node':
+        specifier: ^20
+        version: 20.19.35
+      eslint:
+        specifier: ^9.32.0
+        version: 9.39.3(jiti@2.6.1)
+      typescript:
+        specifier: ^5.9.2
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@20.19.35)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@20.19.35)(typescript@5.9.3))(terser@5.46.0)(yaml@2.8.2)
+
   packages/auth:
     dependencies:
       '@repo/database':

--- a/tests/unit/assign-local-ports.test.ts
+++ b/tests/unit/assign-local-ports.test.ts
@@ -54,6 +54,10 @@ describe("assignLocalPorts", () => {
       "const DEFAULT_PORT = {{LOCAL_API_PORT}};",
     );
     await fs.outputFile(
+      path.join(projectDir, "apps/worker/src/main.ts"),
+      "const DEFAULT_PORT = {{LOCAL_WORKER_PORT}};",
+    );
+    await fs.outputFile(
       path.join(projectDir, "docker-compose.yml"),
       'ports:\n  - "{{LOCAL_POSTGRES_PORT}}:5432"',
     );
@@ -64,12 +68,14 @@ describe("assignLocalPorts", () => {
       app: 3100,
       web: 3101,
       api: 3102,
+      worker: 3103,
       postgres: 5532,
     });
     expect(getPortsForSet(1)).toEqual({
       app: 3200,
       web: 3201,
       api: 3202,
+      worker: 3203,
       postgres: 5632,
     });
   });
@@ -180,6 +186,9 @@ describe("assignLocalPorts", () => {
       fs.readFile(path.join(projectDir, "apps/api/src/main.ts"), "utf-8"),
     ).resolves.toContain("const DEFAULT_PORT = 3202;");
     await expect(
+      fs.readFile(path.join(projectDir, "apps/worker/src/main.ts"), "utf-8"),
+    ).resolves.toContain("const DEFAULT_PORT = 3203;");
+    await expect(
       fs.readFile(path.join(projectDir, "packages/database/README.md"), "utf-8"),
     ).resolves.toContain("localhost:5632");
     await expect(
@@ -241,7 +250,7 @@ describe("assignLocalPorts", () => {
     await expect(
       assignLocalPorts(projectDir, "new-project", selected, {
         homeDir,
-        isPortAvailable: async (port) => port !== selected.ports.app,
+        isPortAvailable: async (port) => port !== selected.ports.worker,
       }),
     ).rejects.toThrow("Selected local development port set is no longer available.");
   });

--- a/tests/unit/prompts.test.ts
+++ b/tests/unit/prompts.test.ts
@@ -50,6 +50,9 @@ describe("getUserChoices", () => {
         ports: getPortsForSet(0),
       },
     });
+    expect(vi.mocked(prompts).mock.calls[1]?.[0]).toMatchObject({
+      message: expect.stringContaining("worker 3103"),
+    });
   });
 
   it("uses argProjectName when provided", async () => {

--- a/tests/unit/template-structure.test.ts
+++ b/tests/unit/template-structure.test.ts
@@ -45,6 +45,49 @@ describe("template structure contracts", () => {
     expect(packageJson.scripts.prebuild).toBe("pnpm run build:deps");
   });
 
+  it("includes a worker NestJS app with worker-specific identity", async () => {
+    const workerPackageJson = await fs.readJson(
+      path.join(TEMPLATE_DIR, "apps/worker/package.json"),
+    );
+    const workerMain = await fs.readFile(
+      path.join(TEMPLATE_DIR, "apps/worker/src/main.ts"),
+      "utf-8",
+    );
+    const workerService = await fs.readFile(
+      path.join(TEMPLATE_DIR, "apps/worker/src/app.service.ts"),
+      "utf-8",
+    );
+    const workerControllerTest = await fs.readFile(
+      path.join(TEMPLATE_DIR, "apps/worker/src/app.controller.test.ts"),
+      "utf-8",
+    );
+
+    expect(workerPackageJson.name).toBe("worker");
+    expect(workerPackageJson.scripts.pretypecheck).toBe("pnpm run generate:deps");
+    expect(workerPackageJson.scripts.typecheck).toBe("tsc --noEmit");
+    expect(workerMain).toContain("{{LOCAL_WORKER_PORT}}");
+    expect(workerMain).not.toContain("{{LOCAL_API_PORT}}");
+    expect(workerMain).toContain('const DEFAULT_HOST = "127.0.0.1";');
+    expect(workerMain).toContain('process.env.HOST || DEFAULT_HOST');
+    expect(workerMain).not.toContain("enableCors");
+    expect(workerService).toContain("jjlabsio-starter-worker");
+    expect(workerControllerTest).toContain("jjlabsio-starter-worker");
+  });
+
+  it("documents the generated worker app", async () => {
+    const rootReadme = await fs.readFile(
+      path.resolve(__dirname, "../../README.md"),
+      "utf-8",
+    );
+    const templateReadme = await fs.readFile(
+      path.join(TEMPLATE_DIR, "README.md"),
+      "utf-8",
+    );
+
+    expect(rootReadme).toContain("apps/worker");
+    expect(templateReadme).toContain("apps/worker");
+  });
+
   it("uses MDF fallback docs structure for generated projects", async () => {
     const expectedDocs = [
       "docs/index.md",


### PR DESCRIPTION
## Summary

- `template/apps/worker`를 API baseline 기반의 별도 NestJS worker scaffold로 추가했습니다.
- worker 전용 local port(`{{LOCAL_WORKER_PORT}}`, 기본 3103), prompt preview, scaffold 완료 출력, docs, lockfile importer를 연결했습니다.
- generated-project smoke가 `typecheck`, `lint`, `test`, `build`, API `/health`, worker `/health`를 검증하도록 확장했습니다.
- scaffold-only worker는 기본 bind host를 `127.0.0.1`로 두고 `HOST` override만 허용하며, CORS는 기본 활성화하지 않도록 보안 리뷰 지적을 반영했습니다.

## Verification

- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test:pack-env`
- `pnpm test:e2e`
- subagent standalone review: PASS
- subagent ship review: GO after security fix

## MDF

- Task: `0009 Add NestJS worker app`
- Spec/plan/build/review/ship artifacts saved under local `.mdf/work/2026-06-22-0009-add-nestjs-worker-app/`
